### PR TITLE
ACL Viewer Window and Configuration of Schema Compatibility Mode 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Allows for playing a set of Messages over different topics into a cluster, see t
 ***
 
 ### Authentication 
-At the moment the UI only supports cluster configs without any authentication
 Within the cluster.json file it is possible to configure Authentication for Kafka and Confluent Schema Registry:
 Note: the secrets have to be given in the json file in plain text. This might be a security issue. Feel free to apply a PR if you want to improve this. 
-
 sslEnabled controls the SSL Authentication method
+
+Config of the Authentication can be done either in cluster.json directly or via the UI.
 
 ###### Example for SSL with mTLS Authentication to the broker: 
  ```

--- a/src/main/java/at/esque/kafka/Controller.java
+++ b/src/main/java/at/esque/kafka/Controller.java
@@ -1,5 +1,6 @@
 package at.esque.kafka;
 
+import at.esque.kafka.acl.viewer.AclViewerController;
 import at.esque.kafka.alerts.ConfirmationAlert;
 import at.esque.kafka.alerts.ErrorAlert;
 import at.esque.kafka.alerts.SuccessAlert;
@@ -584,6 +585,33 @@ public class Controller {
             stage.initOwner(controlledStage);
             stage.initModality(Modality.NONE);
             stage.setTitle("Lag Viewer - " + selectedCluster().getIdentifier());
+            stage.setScene(Main.createStyledScene(root1, 1000, 500));
+            stage.show();
+            centerStageOnControlledStage(stage);
+            stage.setOnCloseRequest(windowEvent -> {
+                controller.stop();
+                consumerHandler.deregisterConsumer(consumerId);
+            });
+        } catch (Exception e) {
+            ErrorAlert.show(e);
+        }
+    }
+
+    @FXML
+    public void aclViewer(ActionEvent actionEvent) {
+        try {
+            FXMLLoader fxmlLoader = injector.getInstance(FXMLLoader.class);
+            fxmlLoader.setLocation(getClass().getResource("/fxml/aclViewer.fxml"));
+            Parent root1 = fxmlLoader.load();
+            AclViewerController controller = fxmlLoader.getController();
+            UUID consumerId = consumerHandler.registerConsumer(selectedCluster(), new TopicMessageTypeConfig(), new HashMap<>());
+            KafkaConsumer consumer = consumerHandler.getConsumer(consumerId).orElseThrow(() -> new RuntimeException("Error getting consumer"));
+            controller.setup(adminClient, consumer);
+            Stage stage = new Stage();
+            stage.getIcons().add(new Image(getClass().getResourceAsStream("/icons/kafkaesque.png")));
+            stage.initOwner(controlledStage);
+            stage.initModality(Modality.NONE);
+            stage.setTitle("ACL Viewer - " + selectedCluster().getIdentifier());
             stage.setScene(Main.createStyledScene(root1, 1000, 500));
             stage.show();
             centerStageOnControlledStage(stage);

--- a/src/main/java/at/esque/kafka/SchemaRegistryBrowserController.java
+++ b/src/main/java/at/esque/kafka/SchemaRegistryBrowserController.java
@@ -7,6 +7,7 @@ import at.esque.kafka.cluster.SslSocketFactoryCreator;
 import at.esque.kafka.controls.FilterableListView;
 import at.esque.kafka.controls.JsonTreeView;
 import at.esque.kafka.controls.KafkaEsqueCodeArea;
+import at.esque.kafka.dialogs.SubjectConfigDialog;
 import at.esque.kafka.handlers.ConfigHandler;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import javafx.collections.FXCollections;
@@ -26,6 +27,7 @@ import org.kordamp.ikonli.javafx.FontIcon;
 
 import javax.net.ssl.SSLSocketFactory;
 import java.util.Collections;
+import java.util.function.ToDoubleBiFunction;
 
 
 public class SchemaRegistryBrowserController {
@@ -55,7 +57,7 @@ public class SchemaRegistryBrowserController {
         try {
             versionComboBox.getSelectionModel().selectedItemProperty().addListener(((observable1, oldValue1, newValue1) -> {
                 if (newValue1 == null) {
-                    schemaTextArea.setText(null);
+                    schemaTextArea.setText("");
                     return;
                 }
                 try {
@@ -127,7 +129,16 @@ public class SchemaRegistryBrowserController {
         deleteItem.setOnAction(event -> {
             deleteSubject();
         });
-        contextMenu.getItems().addAll(deleteItem);
+
+        MenuItem configItem = new MenuItem();
+        configItem.setGraphic(new FontIcon(FontAwesome.COG));
+        configItem.textProperty().set("config");
+        configItem.setOnAction(event -> {
+            SubjectConfigDialog.show(schemaRegistryRestService,subjectListView.getListView().getSelectionModel().getSelectedItem());
+        });
+
+        contextMenu.getItems().add(configItem);
+        contextMenu.getItems().add(deleteItem);
 
         cell.textProperty().bind(cell.itemProperty());
 

--- a/src/main/java/at/esque/kafka/acl/viewer/Acl.java
+++ b/src/main/java/at/esque/kafka/acl/viewer/Acl.java
@@ -1,0 +1,87 @@
+package at.esque.kafka.acl.viewer;
+
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourceType;
+
+public class Acl {
+    private StringProperty resourceType = new SimpleStringProperty();
+    private StringProperty resourceName = new SimpleStringProperty();
+    private StringProperty patternType = new SimpleStringProperty();
+    private StringProperty principal = new SimpleStringProperty();
+    private StringProperty operation = new SimpleStringProperty();
+    private StringProperty permissionType = new SimpleStringProperty();
+    private StringProperty host = new SimpleStringProperty();
+
+    public Acl(ResourceType resourceType, String resourceName, PatternType patternType, String principal, AclOperation operation, AclPermissionType permissionType, String host)
+    {
+        this.resourceType.set(resourceType.toString());
+        this.resourceName.set(resourceName);
+        this.patternType.set(patternType.toString());
+        this.principal.set(principal);
+        this.operation.set(operation.toString());
+        this.permissionType.set(permissionType.toString());
+        this.host.set(host);
+    }
+
+    public String getResourceType() {
+        return resourceType.get();
+    }
+
+    public StringProperty resourceTypeProperty() {
+        return resourceType;
+    }
+
+    public String getResourceName() {
+        return resourceName.get();
+    }
+
+    public StringProperty resourceNameProperty() {
+        return resourceName;
+    }
+
+    public String getPatternType() {
+        return patternType.get();
+    }
+
+    public StringProperty patternTypeProperty() {
+        return patternType;
+    }
+
+    public String getPrincipal() {
+        return principal.get();
+    }
+
+    public StringProperty principalProperty() {
+        return principal;
+    }
+
+    public String getOperation() {
+        return operation.get();
+    }
+
+    public StringProperty operationProperty() {
+        return operation;
+    }
+
+    public String getPermissionType() {
+        return permissionType.get();
+    }
+
+    public StringProperty permissionTypeProperty() {
+        return permissionType;
+    }
+
+    public String getHost() {
+        return host.get();
+    }
+
+    public StringProperty hostProperty() {
+        return host;
+    }
+}
+
+

--- a/src/main/java/at/esque/kafka/acl/viewer/Acl.java
+++ b/src/main/java/at/esque/kafka/acl/viewer/Acl.java
@@ -2,6 +2,7 @@ package at.esque.kafka.acl.viewer;
 
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.resource.PatternType;
@@ -15,16 +16,18 @@ public class Acl {
     private StringProperty operation = new SimpleStringProperty();
     private StringProperty permissionType = new SimpleStringProperty();
     private StringProperty host = new SimpleStringProperty();
+    private AclBinding aclBinding;
 
-    public Acl(ResourceType resourceType, String resourceName, PatternType patternType, String principal, AclOperation operation, AclPermissionType permissionType, String host)
+    public Acl(AclBinding aclBinding)
     {
-        this.resourceType.set(resourceType.toString());
-        this.resourceName.set(resourceName);
-        this.patternType.set(patternType.toString());
-        this.principal.set(principal);
-        this.operation.set(operation.toString());
-        this.permissionType.set(permissionType.toString());
-        this.host.set(host);
+        this.aclBinding = aclBinding;
+        this.resourceType.set(aclBinding.pattern().resourceType().toString());
+        this.resourceName.set(aclBinding.pattern().name());
+        this.patternType.set(aclBinding.pattern().patternType().toString());
+        this.principal.set(aclBinding.entry().principal());
+        this.operation.set(aclBinding.entry().operation().toString());
+        this.permissionType.set(aclBinding.entry().permissionType().toString());
+        this.host.set(aclBinding.entry().host());
     }
 
     public String getResourceType() {
@@ -81,6 +84,11 @@ public class Acl {
 
     public StringProperty hostProperty() {
         return host;
+    }
+
+    public AclBinding getAclBinding()
+    {
+        return aclBinding;
     }
 }
 

--- a/src/main/java/at/esque/kafka/acl/viewer/AclViewerController.java
+++ b/src/main/java/at/esque/kafka/acl/viewer/AclViewerController.java
@@ -1,0 +1,124 @@
+package at.esque.kafka.acl.viewer;
+
+import at.esque.kafka.alerts.ErrorAlert;
+import at.esque.kafka.cluster.KafkaesqueAdminClient;
+import at.esque.kafka.controls.FilterableListView;
+import at.esque.kafka.controls.LagViewerCellContent;
+import at.esque.kafka.lag.viewer.Lag;
+import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.collections.FXCollections;
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.scene.control.*;
+import javafx.scene.control.cell.PropertyValueFactory;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
+
+import java.util.*;
+
+public class AclViewerController {
+
+    @FXML
+    ComboBox<ResourceType> resourceTypeCombo;
+
+    @FXML
+    TextField resourceName;
+
+    @FXML
+    ComboBox<PatternType> resourcePatternCombo;
+
+    @FXML
+    TableView<Acl> resultView;
+
+    @FXML
+    TableColumn<Acl,String> resourceTypeColumn;
+    @FXML
+    TableColumn<Acl,String> resourceNameColumn;
+    @FXML
+    TableColumn<Acl,String> patternTypeColumn;
+    @FXML
+    TableColumn<Acl,String> principalColumn;
+    @FXML
+    TableColumn<Acl,String> operationColumn;
+    @FXML
+    TableColumn<Acl,String> permissionTypeColumn;
+    @FXML
+    TableColumn<Acl,String> hostColumn;
+
+    private KafkaesqueAdminClient adminClient;
+
+    private KafkaConsumer kafkaConsumer;
+
+    private BooleanProperty refreshRunning = new SimpleBooleanProperty(false);
+
+    @FXML
+    public void initialize() {
+        resourceTypeCombo.setItems(FXCollections.observableArrayList( ResourceType.values()));
+        resourcePatternCombo.setItems(FXCollections.observableArrayList(PatternType.values()));
+
+        resourceTypeCombo.getSelectionModel().select(ResourceType.ANY);
+        resourcePatternCombo.getSelectionModel().select(PatternType.ANY);
+
+        //Remove Unkown those are not support in Admin Client for the Query
+        resourceTypeCombo.getItems().remove(ResourceType.UNKNOWN);
+        resourcePatternCombo.getItems().remove(PatternType.UNKNOWN);
+
+
+        resourceTypeColumn.setCellValueFactory(new PropertyValueFactory<>("resourceType"));
+        resourceNameColumn.setCellValueFactory(new PropertyValueFactory<>("resourceName"));
+        patternTypeColumn.setCellValueFactory(new PropertyValueFactory<>("patternType"));
+        principalColumn.setCellValueFactory(new PropertyValueFactory<>("principal"));
+        operationColumn.setCellValueFactory(new PropertyValueFactory<>("operation"));
+        permissionTypeColumn.setCellValueFactory(new PropertyValueFactory<>("permissionType"));
+        hostColumn.setCellValueFactory(new PropertyValueFactory<>("host"));
+
+    }
+
+    public void setup(KafkaesqueAdminClient adminClient, KafkaConsumer kafkaConsumer) {
+        this.adminClient = adminClient;
+        this.kafkaConsumer = kafkaConsumer;
+
+        this.adminClient = adminClient;
+    }
+
+    @FXML
+    private void startSearch(ActionEvent actionEvent) {
+        runInDaemonThread(() -> {
+                Platform.runLater(() -> {
+                    refreshRunning.setValue(true);
+                    List<Acl> aclList = new ArrayList<>();
+
+                    adminClient.getACLs(resourceTypeCombo.getValue(), resourcePatternCombo.getValue(), resourceName.getText())
+                            .forEach(acl -> aclList.add(new Acl(acl.pattern().resourceType(),
+                                                                acl.pattern().name(),
+                                                                acl.pattern().patternType(),
+                                                                acl.entry().principal(),
+                                                                acl.entry().operation(),
+                                                                acl.entry().permissionType(),
+                                                                acl.entry().host())));
+
+                    resultView.setItems(FXCollections.observableArrayList(aclList));
+                });
+            Platform.runLater(() -> refreshRunning.setValue(false));
+        });
+    }
+
+    public void stop(){
+        kafkaConsumer = null;
+    }
+
+    private void runInDaemonThread(Runnable runnable) {
+        Thread daemonThread = new Thread(runnable);
+        daemonThread.setDaemon(true);
+        daemonThread.start();
+    }
+
+}

--- a/src/main/java/at/esque/kafka/acl/viewer/AclViewerController.java
+++ b/src/main/java/at/esque/kafka/acl/viewer/AclViewerController.java
@@ -86,13 +86,6 @@ public class AclViewerController {
         permissionTypeColumn.setCellValueFactory(new PropertyValueFactory<>("permissionType"));
         hostColumn.setCellValueFactory(new PropertyValueFactory<>("host"));
 
-        MenuItem mi1 = new MenuItem("Menu item 1");
-        mi1.setOnAction((ActionEvent event) -> {
-            System.out.println("Menu item 1");
-            Object item = resultView.getSelectionModel().getSelectedItem();
-            System.out.println("Selected item: " + item);
-        });
-
         // Add Delete Context Menu to Table Rows
         resultView.setRowFactory(
                 new Callback<TableView<Acl>, TableRow<Acl>>() {
@@ -131,8 +124,6 @@ public class AclViewerController {
     public void setup(KafkaesqueAdminClient adminClient, KafkaConsumer kafkaConsumer) {
         this.adminClient = adminClient;
         this.kafkaConsumer = kafkaConsumer;
-
-        this.adminClient = adminClient;
     }
 
     @FXML

--- a/src/main/java/at/esque/kafka/acl/viewer/AclViewerController.java
+++ b/src/main/java/at/esque/kafka/acl/viewer/AclViewerController.java
@@ -23,6 +23,8 @@ import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
+import org.kordamp.ikonli.fontawesome.FontAwesome;
+import org.kordamp.ikonli.javafx.FontIcon;
 
 import javax.swing.*;
 import java.awt.event.MouseEvent;
@@ -98,8 +100,10 @@ public class AclViewerController {
                     public TableRow<Acl> call(TableView<Acl> tableView) {
                         final TableRow<Acl> row = new TableRow<>();
                         final ContextMenu rowMenu = new ContextMenu();
-                        MenuItem removeItem = new MenuItem("Delete");
-                        removeItem.setOnAction(new EventHandler<ActionEvent>() {
+
+                        MenuItem deleteItem = new MenuItem("Delete");
+                        deleteItem.setGraphic(new FontIcon(FontAwesome.TRASH));
+                        deleteItem.setOnAction(new EventHandler<ActionEvent>() {
 
                             @Override
                             public void handle(ActionEvent event) {
@@ -115,7 +119,7 @@ public class AclViewerController {
 
                             }
                         });
-                        rowMenu.getItems().addAll(removeItem);
+                        rowMenu.getItems().addAll(deleteItem);
                         row.contextMenuProperty().set(rowMenu);
 
                         return row;

--- a/src/main/java/at/esque/kafka/cluster/KafkaesqueAdminClient.java
+++ b/src/main/java/at/esque/kafka/cluster/KafkaesqueAdminClient.java
@@ -12,14 +12,7 @@ import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -122,6 +115,19 @@ public class KafkaesqueAdminClient {
             ErrorAlert.show(e);
         }
         return Collections.EMPTY_LIST;
+    }
+
+    public void deleteAcl(AclBinding aclBinding)
+    {
+        try {
+            AclBindingFilter aclBindingFilter = new AclBindingFilter(new ResourcePatternFilter(aclBinding.pattern().resourceType(), aclBinding.pattern().name(), aclBinding.pattern().patternType()),
+                    new AccessControlEntryFilter(aclBinding.entry().principal(), aclBinding.entry().host(), aclBinding.entry().operation(), aclBinding.entry().permissionType()));
+
+            adminClient.deleteAcls(Collections.singletonList(aclBindingFilter));
+
+        } catch (Exception e) {
+            ErrorAlert.show(e);
+        }
     }
 
     public ListConsumerGroupOffsetsResult listConsumerGroupOffsets(String groupId){

--- a/src/main/java/at/esque/kafka/dialogs/ClusterConfigDialog.java
+++ b/src/main/java/at/esque/kafka/dialogs/ClusterConfigDialog.java
@@ -89,6 +89,12 @@ public class ClusterConfigDialog {
                                 .bind(copy.trustStorePasswordProperty())
                 ),
                 Group.of(
+                        Field.ofStringType(copy.getSaslSecurityProtocol()==null?"":copy.getSaslSecurityProtocol())
+                                .label("Security Protocol")
+                                .tooltip("SecurityProtocol")
+                                .placeholder("SASL_PLAIN")
+                                .format(new NullFormatStringConverter())
+                                .bind(copy.saslSecurityProtocolProperty()),
                         Field.ofStringType(copy.getSaslMechanism()==null?"":copy.getSaslMechanism())
                                 .label("SASL Mechanism")
                                 .tooltip("SASL Mechanism")

--- a/src/main/java/at/esque/kafka/dialogs/SubjectConfigDialog.java
+++ b/src/main/java/at/esque/kafka/dialogs/SubjectConfigDialog.java
@@ -1,0 +1,122 @@
+package at.esque.kafka.dialogs;
+
+import at.esque.kafka.Main;
+import at.esque.kafka.alerts.ErrorAlert;
+import com.dlsc.formsfx.model.structure.Field;
+import com.dlsc.formsfx.model.structure.Form;
+import com.dlsc.formsfx.model.structure.Group;
+import com.dlsc.formsfx.model.util.BindingMode;
+import com.dlsc.formsfx.view.renderer.FormRenderer;
+import com.dlsc.formsfx.view.util.ColSpan;
+import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ModeGetResponse;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import javafx.beans.property.*;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.Label;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+public class SubjectConfigDialog {
+    private SubjectConfigDialog(){}
+
+    private enum schemaCompatibilityLevel {
+        BACKWARD, BACKWARD_TRANSITIVE,FORWARD,FORWARD_TRANSITIVE,FULL, FULL_TRANSITIVE, NONE;
+    }
+
+    public static void show(RestService schemaRegistryRestService, String selectedSubject) {
+
+        try {
+            //get configured global compatibility level
+            StringProperty globalCompatibilityLevel = new SimpleStringProperty();
+
+            Config globalConfig = schemaRegistryRestService.getConfig(null);
+            globalCompatibilityLevel.set(globalConfig.getCompatibilityLevel());
+
+            // if configured also get the configured level on subject
+            SimpleObjectProperty<schemaCompatibilityLevel> subjectCompatibilityLevel = new SimpleObjectProperty<>();
+            try {
+                Config subjectConfig = schemaRegistryRestService.getConfig(selectedSubject);
+
+                schemaCompatibilityLevel configuredLevel = schemaCompatibilityLevel.valueOf(subjectConfig.getCompatibilityLevel());
+
+                if (configuredLevel == null)
+                {
+                    throw new IllegalArgumentException(String.format("Schema Registry returned an unknown compatibility level (%s)",subjectConfig.getCompatibilityLevel()));
+                }
+
+                subjectCompatibilityLevel.set(configuredLevel);
+            }catch (RestClientException e)
+            {
+                //Nothing configured on subject level
+                if(e.getErrorCode() == 40401)
+                {
+                    subjectCompatibilityLevel.set(null);
+                } else {
+                    throw e;
+                }
+            }
+
+            ListProperty<schemaCompatibilityLevel> schemaCompatibilityLevels = new SimpleListProperty<>(FXCollections.observableArrayList(schemaCompatibilityLevel.values()));
+
+            SimpleObjectProperty<schemaCompatibilityLevel> existingSubjectCompatibilityLevel = new SimpleObjectProperty(subjectCompatibilityLevel.get());
+
+            // Show dialog
+            Form form = Form.of(
+                    Group.of(
+                            Field.ofStringType("Configured schema compatibility level:")
+                                    .editable(false),
+                            Field.ofStringType(globalCompatibilityLevel.getValueSafe())
+                                    .label("Global:")
+                                    .tooltip("Global Schema Compatibility Level")
+                                    .editable(false),
+                            Field.ofSingleSelectionType(schemaCompatibilityLevels)
+                                    .label("Subject:")
+                                    .tooltip("Subject Schema Compatibility Leve")
+                                    .bind(schemaCompatibilityLevels,subjectCompatibilityLevel)
+                    )
+            ).title("Schema Compatibility")
+             .binding(BindingMode.CONTINUOUS);
+
+            Dialog<SimpleObjectProperty> dialog = new Dialog<>();
+            Main.applyIcon(dialog);
+            dialog.setTitle("Subject configuration");
+
+            ButtonType saveConfigButtonType = new ButtonType("Change", ButtonBar.ButtonData.OK_DONE);
+            dialog.getDialogPane().getButtonTypes().addAll(saveConfigButtonType, ButtonType.CANCEL);
+
+            Node addClusterButton = dialog.getDialogPane().lookupButton(saveConfigButtonType);
+            addClusterButton.getStyleClass().add("primary");
+
+            FormRenderer formRenderer = new FormRenderer(form);
+            formRenderer.setPrefWidth(500);
+            dialog.getDialogPane().setContent(formRenderer);
+
+            dialog.setResultConverter(dialogButton -> {
+                if (dialogButton == saveConfigButtonType) {
+                    return subjectCompatibilityLevel;
+                }
+                return null;
+            });
+
+            Optional<SimpleObjectProperty> newSubjectLevel = dialog.showAndWait();
+
+            if(newSubjectLevel.isPresent() && !newSubjectLevel.get().get().equals(existingSubjectCompatibilityLevel.getValue()))
+            {
+                    schemaCompatibilityLevel newLevel = (schemaCompatibilityLevel) newSubjectLevel.get().get();
+                    schemaRegistryRestService.updateCompatibility(newLevel.name(), selectedSubject);
+            }
+
+        } catch (Exception e) {
+            ErrorAlert.show(e);
+        }
+    }
+}

--- a/src/main/resources/fxml/aclViewer.fxml
+++ b/src/main/resources/fxml/aclViewer.fxml
@@ -5,41 +5,42 @@
 <?import javafx.scene.layout.*?>
 
 <?import org.kordamp.ikonli.javafx.FontIcon?>
-<SplitPane fx:controller="at.esque.kafka.acl.viewer.AclViewerController" dividerPositions="0.2236180904522613" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" orientation="VERTICAL" prefHeight="600.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-<items>
-    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="150.0" prefWidth="598.0">
-        <children>
-            <ComboBox fx:id="resourceTypeCombo" layoutX="109.0" layoutY="14.0" prefHeight="25.0" prefWidth="176.0" />
-            <Label layoutX="14.0" layoutY="18.0" text="Resource Type:" />
-            <Label layoutX="14.0" layoutY="52.0" text="Resource Name:" />
-            <TextField fx:id="resourceName" layoutX="109.0" layoutY="48.0" prefHeight="25.0" prefWidth="275.0" />
-            <Label layoutX="299.0" layoutY="18.0" prefHeight="17.0" prefWidth="100.0" text="Resource Pattern:" />
-            <ComboBox fx:id="resourcePatternCombo" layoutX="399.0" layoutY="14.0" prefHeight="25.0" prefWidth="176.0" />
-            <Button fx:id="searchButton" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" mnemonicParsing="false" prefWidth="30.0" layoutX="600.0" layoutY="16" onAction="#startSearch">
-                <styleClass>
-                    <String fx:value="success" />
-                </styleClass>
-                <graphic>
-                    <FontIcon iconColor="WHITE" iconLiteral="fa-search" iconSize="20" />
-                </graphic>
-            </Button>
-        </children>
-    </AnchorPane>
-     <AnchorPane  minHeight="0.0" minWidth="0.0" prefHeight="350.0" prefWidth="1000.0" maxHeight="-Infinity" maxWidth="-Infinity" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-                  AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-         <children>
-             <TableView fx:id="resultView" prefHeight="350.0" prefWidth="1000.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity">
-                 <columns>
-                     <TableColumn fx:id="resourceTypeColumn" editable="false" prefWidth="70.0" text="Res. Type" />
-                     <TableColumn fx:id="resourceNameColumn" editable="false" prefWidth="350.0" text="Resource Name" />
-                     <TableColumn fx:id="patternTypeColumn" editable="false" prefWidth="75.0" text="Pattern Type" />
-                     <TableColumn fx:id="principalColumn" editable="false" prefWidth="300.0" text="Principal" />
-                     <TableColumn fx:id="operationColumn" editable="false" prefWidth="60.0" text="Oper." />
-                     <TableColumn fx:id="permissionTypeColumn" editable="false" prefWidth="60.0" text="PermTyp" />
-                     <TableColumn fx:id="hostColumn" editable="false" prefWidth="75.0" text="Host" />
-                 </columns>
-             </TableView>
-         </children>
-     </AnchorPane>
-</items>
+<SplitPane fx:controller="at.esque.kafka.acl.viewer.AclViewerController" dividerPositions="0.2236180904522613"
+           maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" orientation="VERTICAL"
+           prefHeight="600.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+    <items>
+        <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="150.0" prefWidth="598.0">
+            <children>
+                <ComboBox fx:id="resourceTypeCombo" layoutX="109.0" layoutY="14.0" prefHeight="25.0" prefWidth="176.0"/>
+                <Label layoutX="14.0" layoutY="18.0" text="Resource Type:"/>
+                <Label layoutX="14.0" layoutY="52.0" text="Resource Name:"/>
+                <TextField fx:id="resourceName" layoutX="109.0" layoutY="48.0" prefHeight="25.0" prefWidth="275.0"/>
+                <Label layoutX="299.0" layoutY="18.0" prefHeight="17.0" prefWidth="100.0" text="Resource Pattern:"/>
+                <ComboBox fx:id="resourcePatternCombo" layoutX="399.0" layoutY="14.0" prefHeight="25.0"
+                          prefWidth="176.0"/>
+                <Button fx:id="searchButton" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity"
+                        mnemonicParsing="false" prefWidth="30.0" layoutX="600.0" layoutY="16" onAction="#startSearch">
+                    <styleClass>
+                        <String fx:value="success"/>
+                    </styleClass>
+                    <graphic>
+                        <FontIcon iconColor="WHITE" iconLiteral="fa-search" iconSize="20"/>
+                    </graphic>
+                </Button>
+            </children>
+        </AnchorPane>
+
+        <TableView fx:id="resultView">
+            <columns>
+                <TableColumn fx:id="resourceTypeColumn" editable="false" prefWidth="70.0" text="Res. Type"/>
+                <TableColumn fx:id="resourceNameColumn" editable="false" prefWidth="350.0" text="Resource Name"/>
+                <TableColumn fx:id="patternTypeColumn" editable="false" prefWidth="75.0" text="Pattern Type"/>
+                <TableColumn fx:id="principalColumn" editable="false" prefWidth="300.0" text="Principal"/>
+                <TableColumn fx:id="operationColumn" editable="false" prefWidth="60.0" text="Oper."/>
+                <TableColumn fx:id="permissionTypeColumn" editable="false" prefWidth="60.0" text="PermTyp"/>
+                <TableColumn fx:id="hostColumn" editable="false" prefWidth="75.0" text="Host"/>
+            </columns>
+        </TableView>
+
+    </items>
 </SplitPane>

--- a/src/main/resources/fxml/aclViewer.fxml
+++ b/src/main/resources/fxml/aclViewer.fxml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.*?>
+<?import java.lang.*?>
+<?import javafx.scene.layout.*?>
+
+<?import org.kordamp.ikonli.javafx.FontIcon?>
+<SplitPane fx:controller="at.esque.kafka.acl.viewer.AclViewerController" dividerPositions="0.2236180904522613" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" orientation="VERTICAL" prefHeight="600.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<items>
+    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="264.0" prefWidth="598.0">
+        <children>
+            <ComboBox fx:id="resourceTypeCombo" layoutX="109.0" layoutY="14.0" prefHeight="25.0" prefWidth="176.0" />
+            <Label layoutX="14.0" layoutY="18.0" text="Resource Type:" />
+            <Label layoutX="14.0" layoutY="52.0" text="Resource Name:" />
+            <TextField fx:id="resourceName" layoutX="109.0" layoutY="48.0" prefHeight="25.0" prefWidth="275.0" />
+            <Label layoutX="299.0" layoutY="18.0" prefHeight="17.0" prefWidth="100.0" text="Resource Pattern:" />
+            <ComboBox fx:id="resourcePatternCombo" layoutX="399.0" layoutY="14.0" prefHeight="25.0" prefWidth="176.0" />
+            <Button fx:id="searchButton" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" mnemonicParsing="false" prefWidth="30.0" layoutX="600.0" layoutY="16" onAction="#startSearch">
+                <styleClass>
+                    <String fx:value="success" />
+                </styleClass>
+                <graphic>
+                    <FontIcon iconColor="WHITE" iconLiteral="fa-search" iconSize="20" />
+                </graphic>
+            </Button>
+        </children></AnchorPane>
+    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="400.0" prefWidth="1000.0" >
+        <children>
+            <ScrollPane prefHeight="350.0" prefWidth="1000.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity">
+                <content>
+                    <AnchorPane  minHeight="0.0" minWidth="0.0" prefHeight="350.0" prefWidth="1000.0" maxHeight="-Infinity" maxWidth="-Infinity">
+                        <children>
+                            <TableView fx:id="resultView" prefHeight="350.0" prefWidth="1000.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity">
+                                <columns>
+                                    <TableColumn fx:id="resourceTypeColumn" editable="false" prefWidth="70.0" text="Res. Type" />
+                                    <TableColumn fx:id="resourceNameColumn" editable="false" prefWidth="350.0" text="Resource Name" />
+                                    <TableColumn fx:id="patternTypeColumn" editable="false" prefWidth="75.0" text="Pattern Type" />
+                                    <TableColumn fx:id="principalColumn" editable="false" prefWidth="300.0" text="Principal" />
+                                    <TableColumn fx:id="operationColumn" editable="false" prefWidth="60.0" text="Oper." />
+                                    <TableColumn fx:id="permissionTypeColumn" editable="false" prefWidth="60.0" text="PermTyp" />
+                                    <TableColumn fx:id="hostColumn" editable="false" prefWidth="75.0" text="Host" />
+                                </columns>
+                            </TableView>
+                        </children>
+                    </AnchorPane>
+                </content>
+            </ScrollPane>
+        </children></AnchorPane>
+</items>
+</SplitPane>

--- a/src/main/resources/fxml/aclViewer.fxml
+++ b/src/main/resources/fxml/aclViewer.fxml
@@ -7,7 +7,7 @@
 <?import org.kordamp.ikonli.javafx.FontIcon?>
 <SplitPane fx:controller="at.esque.kafka.acl.viewer.AclViewerController" dividerPositions="0.2236180904522613" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" orientation="VERTICAL" prefHeight="600.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
 <items>
-    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="264.0" prefWidth="598.0">
+    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="150.0" prefWidth="598.0">
         <children>
             <ComboBox fx:id="resourceTypeCombo" layoutX="109.0" layoutY="14.0" prefHeight="25.0" prefWidth="176.0" />
             <Label layoutX="14.0" layoutY="18.0" text="Resource Type:" />
@@ -23,28 +23,23 @@
                     <FontIcon iconColor="WHITE" iconLiteral="fa-search" iconSize="20" />
                 </graphic>
             </Button>
-        </children></AnchorPane>
-    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="400.0" prefWidth="1000.0" >
-        <children>
-            <ScrollPane prefHeight="350.0" prefWidth="1000.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity">
-                <content>
-                    <AnchorPane  minHeight="0.0" minWidth="0.0" prefHeight="350.0" prefWidth="1000.0" maxHeight="-Infinity" maxWidth="-Infinity">
-                        <children>
-                            <TableView fx:id="resultView" prefHeight="350.0" prefWidth="1000.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity">
-                                <columns>
-                                    <TableColumn fx:id="resourceTypeColumn" editable="false" prefWidth="70.0" text="Res. Type" />
-                                    <TableColumn fx:id="resourceNameColumn" editable="false" prefWidth="350.0" text="Resource Name" />
-                                    <TableColumn fx:id="patternTypeColumn" editable="false" prefWidth="75.0" text="Pattern Type" />
-                                    <TableColumn fx:id="principalColumn" editable="false" prefWidth="300.0" text="Principal" />
-                                    <TableColumn fx:id="operationColumn" editable="false" prefWidth="60.0" text="Oper." />
-                                    <TableColumn fx:id="permissionTypeColumn" editable="false" prefWidth="60.0" text="PermTyp" />
-                                    <TableColumn fx:id="hostColumn" editable="false" prefWidth="75.0" text="Host" />
-                                </columns>
-                            </TableView>
-                        </children>
-                    </AnchorPane>
-                </content>
-            </ScrollPane>
-        </children></AnchorPane>
+        </children>
+    </AnchorPane>
+     <AnchorPane  minHeight="0.0" minWidth="0.0" prefHeight="350.0" prefWidth="1000.0" maxHeight="-Infinity" maxWidth="-Infinity" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                  AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+         <children>
+             <TableView fx:id="resultView" prefHeight="350.0" prefWidth="1000.0" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity">
+                 <columns>
+                     <TableColumn fx:id="resourceTypeColumn" editable="false" prefWidth="70.0" text="Res. Type" />
+                     <TableColumn fx:id="resourceNameColumn" editable="false" prefWidth="350.0" text="Resource Name" />
+                     <TableColumn fx:id="patternTypeColumn" editable="false" prefWidth="75.0" text="Pattern Type" />
+                     <TableColumn fx:id="principalColumn" editable="false" prefWidth="300.0" text="Principal" />
+                     <TableColumn fx:id="operationColumn" editable="false" prefWidth="60.0" text="Oper." />
+                     <TableColumn fx:id="permissionTypeColumn" editable="false" prefWidth="60.0" text="PermTyp" />
+                     <TableColumn fx:id="hostColumn" editable="false" prefWidth="75.0" text="Host" />
+                 </columns>
+             </TableView>
+         </children>
+     </AnchorPane>
 </items>
 </SplitPane>

--- a/src/main/resources/fxml/mainScene.fxml
+++ b/src/main/resources/fxml/mainScene.fxml
@@ -187,6 +187,11 @@
                                         <FontIcon iconLiteral="fa-copy"/>
                                     </graphic>
                                 </MenuItem>
+                                <MenuItem mnemonicParsing="false" onAction="#aclViewer" text="AclViewer">
+                                    <graphic>
+                                        <FontIcon iconLiteral="fa-lock"/>
+                                    </graphic>
+                                </MenuItem>
                             </items>
                         </Menu>
                         <Menu mnemonicParsing="false" text="Schema Registry">


### PR DESCRIPTION
New features: 
* New window which allows to search and show the kafka acls for all supported resources (only kafka acls no confluent RBAC ACLs)
* It is also possible to delete single ACLs via context menu
* New context menu entry "config" for subjects in SR Browser which allows to view and change the configured schema compatibility level 

Small fix: 
* When hitting the refresh button in SR Browser an NPE was thrown (without an error dialog) this was also fixed