### PR TITLE
Improvement of "getTopics" to add timeout and process in daemon thread instead of UI thread

### DIFF
--- a/src/main/java/at/esque/kafka/Controller.java
+++ b/src/main/java/at/esque/kafka/Controller.java
@@ -109,8 +109,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
@@ -460,7 +459,8 @@ public class Controller {
             stopWatch.start();
             LOGGER.info("Started getting topics for cluster");
             backGroundTaskHolder.setIsInProgress(true);
-            Platform.runLater(() -> topicListView.setItems(adminClient.getTopics()));
+            topicListView.setItems(adminClient.getTopics());
+
         } finally {
             stopWatch.stop();
             LOGGER.info("Finished getting topics for cluster [{}]", stopWatch);
@@ -1216,4 +1216,6 @@ public class Controller {
     private void updateTabName(PinTab tab, ClusterConfig clusterConfig, String name) {
         Platform.runLater(() -> tab.setText(clusterConfig.getIdentifier() + " - " + name));
     }
+
+
 }

--- a/src/main/java/at/esque/kafka/cluster/KafkaesqueAdminClient.java
+++ b/src/main/java/at/esque/kafka/cluster/KafkaesqueAdminClient.java
@@ -1,6 +1,7 @@
 package at.esque.kafka.cluster;
 
 import at.esque.kafka.alerts.ErrorAlert;
+import at.esque.kafka.handlers.ConfigHandler;
 import at.esque.kafka.lag.viewer.Lag;
 import at.esque.kafka.topics.DescribeTopicWrapper;
 import javafx.application.Platform;
@@ -44,7 +45,7 @@ import java.util.stream.Collectors;
 
 public class KafkaesqueAdminClient {
     private AdminClient adminClient;
-
+    
     public KafkaesqueAdminClient(String bootstrapServers, Map<String, String> sslProps, Map<String, String> saslProps) {
         Properties props = new Properties();
         props.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
@@ -53,6 +54,7 @@ public class KafkaesqueAdminClient {
         props.putAll(saslProps);
 
         this.adminClient = AdminClient.create(props);
+
     }
 
     public Set<String> getTopics() {
@@ -60,9 +62,9 @@ public class KafkaesqueAdminClient {
         options.listInternal(true);
         ListTopicsResult result = adminClient.listTopics(options);
         try {
-            return result.names().get();
-        } catch (Exception e) {
-            ErrorAlert.show(e);
+            return result.names().get(15, TimeUnit.SECONDS);
+         } catch (Exception e) {
+            Platform.runLater(() -> ErrorAlert.show(e));
         }
         return new HashSet<>();
     }


### PR DESCRIPTION
But "getTopic"s of the main scene back into the daemon task and add a… Timout + Error Dialog if the topics cannot be fetched within 15 seconds.

Otherwise KafkaEsque freezes if the cluster is just not reachable when you select it in the drop down