### PR TITLE
support "ssl.endpoint.identification.algorithm" in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ you can use only Basic Auth if you SR is only protected with basic auth, you can
     }
  ```
 
+###### Using SSL without domain name 
+In some situation you might need to use ip address for your bootstrap server and SSL. 
+With default config the API does a host name identification which fails in those scenarios with 
+```
+java.security.cert.CertificateException: No subject alternative names matching IP address .... found
+```
+If you select the toggle "No SSL Endpoint Identification" the kafka property "ssl.endpoint.identification.algorithm" 
+is set to an empty string so that this identification is suppressed 
+
 ###### Settings
 
 Check the settings.yaml in the <user.home>/.kafkaesque directory for cluster independent application settings

--- a/src/main/java/at/esque/kafka/cluster/ClusterConfig.java
+++ b/src/main/java/at/esque/kafka/cluster/ClusterConfig.java
@@ -27,6 +27,7 @@ public class ClusterConfig {
     private StringProperty kafkaConnectBasicAuthUser = new SimpleStringProperty();
     private StringProperty kafkaConnectBasicAuthPassword = new SimpleStringProperty();
     private BooleanProperty kafkaConnectuseSsl = new SimpleBooleanProperty();
+    private BooleanProperty suppressSslEndPointIdentification = new SimpleBooleanProperty();
 
     public ClusterConfig() {
     }
@@ -54,6 +55,7 @@ public class ClusterConfig {
             this.setkafkaConnectBasicAuthUser(existingConfig.getkafkaConnectBasicAuthUser());
             this.setkafkaConnectBasicAuthPassword(existingConfig.getkafkaConnectBasicAuthPassword());
             this.setKafkaConnectuseSsl(existingConfig.isKafkaConnectuseSsl());
+            this.setsuppressSslEndPointIdentification(existingConfig.issuppressSslEndPointIdentification());
         }
     }
 
@@ -294,6 +296,20 @@ public class ClusterConfig {
             return false;
         }
         return kafkaConnectUrl.get().toLowerCase().startsWith("https:");
+    }
+
+
+    @JsonProperty("suppressSslEndPointIdentification")
+    public boolean issuppressSslEndPointIdentification() {
+        return suppressSslEndPointIdentification.get();
+    }
+
+    public BooleanProperty suppressSslEndPointIdentificationProperty() {
+        return suppressSslEndPointIdentification;
+    }
+
+    public void setsuppressSslEndPointIdentification(boolean suppressSslEndPointIdentification) {
+        this.suppressSslEndPointIdentification.set(suppressSslEndPointIdentification);
     }
 
 

--- a/src/main/java/at/esque/kafka/dialogs/ClusterConfigDialog.java
+++ b/src/main/java/at/esque/kafka/dialogs/ClusterConfigDialog.java
@@ -33,6 +33,7 @@ public class ClusterConfigDialog {
     public static final String LABEL_KAFKA_CONNECT_BASIC_AUTH_USER = "Kafka Connect Basic Auth User";
     public static final String LABEL_KAFKA_CONNECT_BASIC_AUTH_PASSWORD = "Kafka Connect Basic Auth Password";
     public static final String LABEL_USE_SSL_CONFIGURATION = "use SSL Configuration";
+    public static final String LABEL_SUPPRESS_SSL_ENDPOINT_IDENTIFICATION = "no SSL Endpoint Identification";
 
     private ClusterConfigDialog(){}
 
@@ -110,6 +111,10 @@ public class ClusterConfigDialog {
                                 .label(LABEL_ENABLE_SSL)
                                 .tooltip(LABEL_ENABLE_SSL)
                                 .bind(copy.sslEnabledProperty()),
+                        Field.ofBooleanType(copy.issuppressSslEndPointIdentification())
+                                .label(LABEL_SUPPRESS_SSL_ENDPOINT_IDENTIFICATION)
+                                .tooltip(LABEL_SUPPRESS_SSL_ENDPOINT_IDENTIFICATION)
+                                .bind(copy.suppressSslEndPointIdentificationProperty()),
                         Field.ofStringType(copy.getKeyStoreLocation()==null?"":copy.getKeyStoreLocation())
                                 .label(LABEL_KEY_STORE_LOCATION)
                                 .tooltip(LABEL_KEY_STORE_LOCATION)

--- a/src/main/java/at/esque/kafka/handlers/ConfigHandler.java
+++ b/src/main/java/at/esque/kafka/handlers/ConfigHandler.java
@@ -213,7 +213,11 @@ public class ConfigHandler {
             props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
         }
 
-        if (config.isSchemaRegistryUseSsl()) {
+        if(config.issuppressSslEndPointIdentification()) {
+            props.put("ssl.endpoint.identification.algorithm", "");
+        }
+
+        if (config.isSchemaRegistryHttps()) {
             props.put(SchemaRegistryClientConfig.CLIENT_NAMESPACE + CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL");
         }
 


### PR DESCRIPTION
Add Option to set "ssl.endpoint.identification.algorithm" to emptystring - needed if you want to connect to a Kafka Cluster which has no DNS Name and you still need to use SSL