### PR TITLE
Add a workflow to bump the Homebrew cask version

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -1,0 +1,25 @@
+name: Bump Homebrew version
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag-name:
+        description: 'The git tag name to bump the cask to'
+        required: true
+
+jobs:
+  homebrew:
+    name: Bump Homebrew cask
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MWin123/bump-homebrew-formula-action@v0.3.0
+        with:
+          formula-name: homebrew-esque
+          formula-path: Casks/kafkaesque.rb
+          homebrew-tap: patschuh/homebrew-esque
+          base-branch: main
+          create-pullrequest: true
+          tag-name: ${{ github.event.inputs.tag-name }}
+          download-url: https://github.com/patschuh/KafkaEsque/releases/download/v${{ github.event.inputs.tag-name }}/kafkaesque-${{ github.event.inputs.tag-name }}.dmg
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
Currently, the workflow is triggered manually. If it works as expected, it can be added to the existing "Gradle Build" workflow. Fixes #20.

The workflow ran successfully with my forks, and generated this PR (https://github.com/MWin123/homebrew-esque/pull/2). Unfortunately, the run history from the workflows is gone because I had to create a new fork to submit this PR.

I forked the GitHub action [bump-homebrew-formula-action](https://github.com/marketplace/actions/bump-homebrew-formula) because it doesn't fully work with casks yet, see my open issue ([Support for Homebrew Cask](https://github.com/mislav/bump-homebrew-formula-action/issues/42)). If the author implements a fix, we can switch back to the original version.

> The COMMITTER_TOKEN secret is required because this action will want to write to an external repository. You can [generate a new PAT here](https://github.com/settings/tokens) and give it public_repo (or repo if the homebrew tap repository is private) scopes.

It's necessary to create a `COMMITTER_TOKEN` secret for this repo, see the action's description for details.