### PR TITLE
Enhancing KafkaEsque with protobuf functionalities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = 'at.esque.kafka'
-version = '2.6.0'
+version = '2.7.0'
 
 repositories {
     mavenCentral()
@@ -42,6 +42,7 @@ dependencies {
     implementation 'com.opencsv:opencsv:5.5.2'
     implementation 'io.confluent:kafka-schema-registry:7.3.0'
     implementation 'io.confluent:kafka-avro-serializer:6.2.7'
+    implementation 'io.confluent:kafka-protobuf-serializer:6.2.7'
     implementation 'org.apache.avro:avro:1.11.1'
     implementation 'com.google.inject:guice:5.0.1'
     implementation 'org.fxmisc.richtext:richtextfx:0.10.7'

--- a/src/main/java/at/esque/kafka/CreateSchemaController.java
+++ b/src/main/java/at/esque/kafka/CreateSchemaController.java
@@ -4,8 +4,10 @@ import at.esque.kafka.alerts.ErrorAlert;
 import at.esque.kafka.alerts.SuccessAlert;
 import at.esque.kafka.controls.KafkaEsqueCodeArea;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import javafx.collections.FXCollections;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextField;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
@@ -23,6 +25,8 @@ public class CreateSchemaController {
     private TextField subjectTextField;
     @FXML
     private KafkaEsqueCodeArea schemaTextArea;
+    @FXML
+    private ComboBox<String> schemaTypeComboBox;
 
     private RestService restService;
 
@@ -31,7 +35,12 @@ public class CreateSchemaController {
     public void addSchema(ActionEvent actionEvent) {
 
         try {
-            restService.registerSchema(schemaTextArea.getText(), subjectTextField.getText());
+            restService.registerSchema(
+                    schemaTextArea.getText(),
+                    schemaTypeComboBox.getSelectionModel().getSelectedItem(),
+                    null,
+                    subjectTextField.getText());
+
             SuccessAlert.show("Success", null, "Schema added successfully!", getWindow());
         } catch (Exception e) {
             ErrorAlert.show(e, getWindow());
@@ -58,6 +67,8 @@ public class CreateSchemaController {
 
     public void setup(String selectedSubject, RestService restService, Stage stage) {
         this.restService = restService;
+        this.schemaTypeComboBox.setItems(FXCollections.observableArrayList("AVRO", "PROTOBUF"));
+        this.schemaTypeComboBox.getSelectionModel().select(0);
         this.stage = stage;
         if (selectedSubject != null) {
             subjectTextField.setText(selectedSubject);

--- a/src/main/java/at/esque/kafka/CreateSchemaController.java
+++ b/src/main/java/at/esque/kafka/CreateSchemaController.java
@@ -10,7 +10,6 @@ import javafx.scene.control.TextField;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import javafx.stage.Window;
-import org.apache.avro.Schema;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,9 +30,7 @@ public class CreateSchemaController {
 
     public void addSchema(ActionEvent actionEvent) {
 
-        Schema.Parser parser = new Schema.Parser();
         try {
-            parser.parse(schemaTextArea.getText());
             restService.registerSchema(schemaTextArea.getText(), subjectTextField.getText());
             SuccessAlert.show("Success", null, "Schema added successfully!", getWindow());
         } catch (Exception e) {

--- a/src/main/java/at/esque/kafka/JsonUtils.java
+++ b/src/main/java/at/esque/kafka/JsonUtils.java
@@ -13,6 +13,11 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.Struct;
+import com.google.protobuf.util.JsonFormat;
 import javafx.scene.control.TreeItem;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
@@ -349,5 +354,22 @@ public final class JsonUtils {
         } else {
             recursivelyAddElements((String.valueOf(value)), treeItem);
         }
+    }
+
+    public static Message fromJson(String json) {
+        Struct.Builder structBuilder = Struct.newBuilder();
+        try {
+            JsonFormat.parser().ignoringUnknownFields().merge(json, structBuilder);
+        } catch (InvalidProtocolBufferException e) {
+            throw new RuntimeException(e);
+        }
+        return structBuilder.build();
+    }
+
+    public static String toJson(MessageOrBuilder messageOrBuilder) throws IOException {
+        if (messageOrBuilder == null) {
+            return null;
+        }
+        return JsonFormat.printer().print(messageOrBuilder);
     }
 }

--- a/src/main/java/at/esque/kafka/MessageType.java
+++ b/src/main/java/at/esque/kafka/MessageType.java
@@ -12,5 +12,6 @@ public enum MessageType {
     BYTEARRAY,
     BYTEBUFFER,
     BYTES,
-    UUID
+    UUID,
+    PROTOBUF_SR
 }

--- a/src/main/java/at/esque/kafka/PublisherController.java
+++ b/src/main/java/at/esque/kafka/PublisherController.java
@@ -126,8 +126,7 @@ public class PublisherController {
                 }
             }
         }
-        if (MessageType.AVRO_TOPIC_RECORD_NAME_STRATEGY.equals(configForTopic.getValueType())
-                || MessageType.PROTOBUF_SR.equals(configForTopic.getValueType())) {
+        if (MessageType.AVRO_TOPIC_RECORD_NAME_STRATEGY.equals(configForTopic.getValueType())) {
             valueTypeSelectCombobox.setVisible(true);
             if (topicMessageTypes == null) {
                 try {

--- a/src/main/java/at/esque/kafka/PublisherController.java
+++ b/src/main/java/at/esque/kafka/PublisherController.java
@@ -126,7 +126,8 @@ public class PublisherController {
                 }
             }
         }
-        if (MessageType.AVRO_TOPIC_RECORD_NAME_STRATEGY.equals(configForTopic.getValueType())) {
+        if (MessageType.AVRO_TOPIC_RECORD_NAME_STRATEGY.equals(configForTopic.getValueType())
+                || MessageType.PROTOBUF_SR.equals(configForTopic.getValueType())) {
             valueTypeSelectCombobox.setVisible(true);
             if (topicMessageTypes == null) {
                 try {

--- a/src/main/java/at/esque/kafka/SchemaCompatibilityCheckController.java
+++ b/src/main/java/at/esque/kafka/SchemaCompatibilityCheckController.java
@@ -3,6 +3,7 @@ package at.esque.kafka;
 import at.esque.kafka.alerts.ErrorAlert;
 import at.esque.kafka.controls.KafkaEsqueCodeArea;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
@@ -40,7 +41,8 @@ public class SchemaCompatibilityCheckController {
     public void addSchema(ActionEvent actionEvent) {
 
         try {
-            List<String> compatibility = restService.testCompatibility(schemaTextArea.getText(), subjectTextField.getText(), versionTextField.getText());
+            Schema schema = restService.getVersion(subjectTextField.getText(), Integer.parseInt(versionTextField.getText()));
+            List<String> compatibility = restService.testCompatibility(schemaTextArea.getText(), schema.getSchemaType(), null, subjectTextField.getText(), versionTextField.getText(), false);
 
             if (compatibility.isEmpty()) {
                 resultLabel.setTextFill(Color.web("#3d7a3d"));

--- a/src/main/java/at/esque/kafka/SchemaCompatibilityCheckController.java
+++ b/src/main/java/at/esque/kafka/SchemaCompatibilityCheckController.java
@@ -11,7 +11,6 @@ import javafx.scene.paint.Color;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import javafx.stage.Window;
-import org.apache.avro.Schema;
 
 import java.io.File;
 import java.io.IOException;
@@ -40,10 +39,7 @@ public class SchemaCompatibilityCheckController {
 
     public void addSchema(ActionEvent actionEvent) {
 
-        Schema.Parser parser = new Schema.Parser();
         try {
-            parser.parse(schemaTextArea.getText());
-
             List<String> compatibility = restService.testCompatibility(schemaTextArea.getText(), subjectTextField.getText(), versionTextField.getText());
 
             if (compatibility.isEmpty()) {

--- a/src/main/java/at/esque/kafka/SchemaRegistryBrowserController.java
+++ b/src/main/java/at/esque/kafka/SchemaRegistryBrowserController.java
@@ -55,7 +55,9 @@ public class SchemaRegistryBrowserController {
     @FXML
     private Label schemaIdLabel;
     @FXML
-    public Label compatibilityLabel;
+    private Label compatibilityLabel;
+    @FXML
+    private Label typeLabel;
 
 
     public void setup(ClusterConfig selectedConfig, ConfigHandler configHandler) {
@@ -78,7 +80,8 @@ public class SchemaRegistryBrowserController {
                 try {
                     Schema schema = schemaRegistryRestService.getVersion(subjectListView.getListView().getSelectionModel().getSelectedItem(), newValue1);
                     schemaIdLabel.setText(String.valueOf(schema.getId()));
-                    schemaTextArea.setText(JsonUtils.formatJson(schema.getSchema()));
+                    schemaTextArea.setText("AVRO".equals(schema.getSchemaType()) ? JsonUtils.formatJson(schema.getSchema()) : schema.getSchema());
+                    typeLabel.setText(schema.getSchemaType());
                 } catch (Exception e) {
                     ErrorAlert.show(e, getWindow());
                 }

--- a/src/main/java/at/esque/kafka/cluster/TopicMessageTypeConfig.java
+++ b/src/main/java/at/esque/kafka/cluster/TopicMessageTypeConfig.java
@@ -58,7 +58,13 @@ public class TopicMessageTypeConfig {
         this.valueType.set(valueType.name());
     }
 
-    public boolean containsAvro() {
-        return getValueType() == MessageType.AVRO || getValueType() == MessageType.AVRO_TOPIC_RECORD_NAME_STRATEGY || getKeyType() == MessageType.AVRO || getKeyType() == MessageType.AVRO_TOPIC_RECORD_NAME_STRATEGY;
+    public boolean requiresSchemaRegistry() {
+        return getValueType() == MessageType.AVRO ||
+                getValueType() == MessageType.AVRO_TOPIC_RECORD_NAME_STRATEGY ||
+                getValueType() == MessageType.PROTOBUF_SR ||
+                getKeyType() == MessageType.AVRO ||
+                getKeyType() == MessageType.AVRO_TOPIC_RECORD_NAME_STRATEGY ||
+                getKeyType() == MessageType.PROTOBUF_SR
+                ;
     }
 }

--- a/src/main/java/at/esque/kafka/handlers/ConsumerHandler.java
+++ b/src/main/java/at/esque/kafka/handlers/ConsumerHandler.java
@@ -65,7 +65,7 @@ public class ConsumerHandler {
         consumerProps.put(KafkaAvroSerializerConfig.AVRO_USE_LOGICAL_TYPE_CONVERTERS_CONFIG, configHandler.getSettingsProperties().get(Settings.ENABLE_AVRO_LOGICAL_TYPE_CONVERSIONS));
         consumerProps.setProperty("kafkaesque.cluster.id", config.getIdentifier());
         consumerProps.put("kafkaesque.confighandler", configHandler);
-        if (topicMessageTypeConfig.containsAvro() && StringUtils.isEmpty(config.getSchemaRegistry())) {
+        if (topicMessageTypeConfig.requiresSchemaRegistry() && StringUtils.isEmpty(config.getSchemaRegistry())) {
             Optional<String> input = SystemUtils.showInputDialog("http://localhost:8081", "Add schema-registry url", "this cluster config is missing a schema registry url please add it now", "schema-registry URL");
             if (!input.isPresent()) {
                 throw new MissingSchemaRegistryException(config.getIdentifier());

--- a/src/main/java/at/esque/kafka/serialization/ForgivingProtobufAvroDeserializer.java
+++ b/src/main/java/at/esque/kafka/serialization/ForgivingProtobufAvroDeserializer.java
@@ -1,0 +1,33 @@
+package at.esque.kafka.serialization;
+
+import com.google.protobuf.Message;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class ForgivingProtobufAvroDeserializer implements Deserializer<Object> {
+
+    private KafkaProtobufDeserializer<Message> baseDeserializer = new KafkaProtobufDeserializer<>();
+    private static final Logger logger = LoggerFactory.getLogger(ForgivingProtobufAvroDeserializer.class);
+
+    public Object deserialize(byte[] bytes) {
+        throw new UnsupportedOperationException();
+    }
+
+    public Object deserialize(String s, byte[] bytes) {
+        try {
+            return baseDeserializer.deserialize(s, bytes);
+        } catch (Exception e) {
+            logger.warn("Failed Protobuf deserialization in topic {}", s);
+        }
+        return "Failed Protobuf deserialization! Content as String: " + new String(bytes);
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        baseDeserializer.configure(configs, isKey);
+    }
+}

--- a/src/main/resources/fxml/createSchema.fxml
+++ b/src/main/resources/fxml/createSchema.fxml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import at.esque.kafka.controls.KafkaEsqueCodeArea?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TextArea?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.control.ToolBar?>
@@ -14,7 +15,6 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 <?import java.lang.String?>
-<?import at.esque.kafka.controls.KafkaEsqueCodeArea?>
 <BorderPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="0.0" minWidth="0.0"
             xmlns="http://javafx.com/javafx/8.0.172-ea" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="at.esque.kafka.CreateSchemaController">
@@ -30,6 +30,7 @@
                                 <String fx:value="primary"/>
                             </styleClass>
                         </Button>
+                        <ComboBox fx:id="schemaTypeComboBox" prefWidth="150.0" styleClass="first"/>
                     </children>
                 </HBox>
             </items>
@@ -63,7 +64,7 @@
                         <HBox>
                             <children>
                                 <KafkaEsqueCodeArea fx:id="schemaTextArea" maxHeight="1.7976931348623157E308"
-                                          maxWidth="1.7976931348623157E308" HBox.hgrow="ALWAYS"/>
+                                                    maxWidth="1.7976931348623157E308" HBox.hgrow="ALWAYS"/>
                                 <VBox>
                                     <children>
                                         <Label alignment="CENTER" maxWidth="1.7976931348623157E308"

--- a/src/main/resources/fxml/schemaRegistryBrowser.fxml
+++ b/src/main/resources/fxml/schemaRegistryBrowser.fxml
@@ -86,6 +86,11 @@
                                        fx:id="compatibilityLabel"
                                        minWidth="5"
                                 />
+                                <Text text="Type: "/>
+                                <Label text="     "
+                                       fx:id="typeLabel"
+                                       minWidth="5"
+                                />
                             </items>
                         </ToolBar>
                     </top>


### PR DESCRIPTION
By merging this PR it is now possible to:
* Use protobuf in KafkaEsque
* Consume protobuf messages
* Produce protobuf messages
* Trace protobuf messages
* Use schema registry compatibility check for protobuf messages