### PR TITLE
make json-tree show the size of an array

### DIFF
--- a/src/main/java/at/esque/kafka/JsonUtils.java
+++ b/src/main/java/at/esque/kafka/JsonUtils.java
@@ -333,6 +333,7 @@ public final class JsonUtils {
             treeItem.setExpanded(true);
             applyCorrectAdder(childNode, newItem);
         });
+        treeItem.setPropertyName(treeItem.getPropertyName() + " (" + i.get() + ")");
     }
 
     private static void recursivelyAddElements(TextNode val, JsonTreeItem treeItem) {


### PR DESCRIPTION
Currently arrays in the JSONTreeView don't show their size so we need to expand the array and look at the index of the last entry to know the size. This is easy for small arrays but if it is a large one it gets anoying, so i fixed it. 