### PR TITLE
Fix for Message Books feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     testImplementation 'org.springframework.kafka:spring-kafka-test:3.1.3'
     testImplementation 'com.google.code.tempus-fugit:tempus-fugit:1.1'
     testImplementation 'org.testfx:testfx-junit:4.0.15-alpha'
+    testImplementation 'org.testfx:testfx-core:4.0.18'
 }
 
 application {
@@ -122,6 +123,10 @@ task versionFile() {
 "name": "KakfaEsque"
 }"""
     }
+}
+
+test {
+    useJUnit()
 }
 
 tasks.named('processResources') { dependsOn('versionFile') }

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ dependencies {
     testImplementation 'org.springframework.kafka:spring-kafka-test:3.1.3'
     testImplementation 'com.google.code.tempus-fugit:tempus-fugit:1.1'
     testImplementation 'org.testfx:testfx-junit:4.0.15-alpha'
-    testImplementation 'org.testfx:testfx-core:4.0.18'
 }
 
 application {

--- a/src/main/java/at/esque/kafka/topics/model/KafkaMessageBookWrapper.java
+++ b/src/main/java/at/esque/kafka/topics/model/KafkaMessageBookWrapper.java
@@ -1,11 +1,11 @@
-package at.esque.kafka.topics;
+package at.esque.kafka.topics.model;
 
-public class KafkaMessagBookWrapper {
+public class KafkaMessageBookWrapper {
 
     private String targetTopic;
-    private KafkaMessage wrappedMessage;
+    private KafkaMessageForMessageBook wrappedMessage;
 
-    public KafkaMessagBookWrapper(String targetTopic, KafkaMessage wrappedMessage) {
+    public KafkaMessageBookWrapper(String targetTopic, KafkaMessageForMessageBook wrappedMessage) {
         this.targetTopic = targetTopic;
         this.wrappedMessage = wrappedMessage;
     }
@@ -14,7 +14,7 @@ public class KafkaMessagBookWrapper {
         return targetTopic;
     }
 
-    public KafkaMessage getWrappedMessage() {
+    public KafkaMessageForMessageBook getWrappedMessage() {
         return wrappedMessage;
     }
 
@@ -57,6 +57,4 @@ public class KafkaMessagBookWrapper {
     public String getTimestamp() {
         return wrappedMessage.getTimestamp();
     }
-
-
 }

--- a/src/main/java/at/esque/kafka/topics/model/KafkaMessageForMessageBook.java
+++ b/src/main/java/at/esque/kafka/topics/model/KafkaMessageForMessageBook.java
@@ -1,0 +1,60 @@
+package at.esque.kafka.topics.model;
+
+
+public class KafkaMessageForMessageBook {
+
+    private int partition;
+    private String key;
+    private String keyType;
+    private String value;
+    private String valueType;
+    private String timestamp;
+
+    public int getPartition() {
+        return partition;
+    }
+
+    public void setPartition(int partition) {
+        this.partition = partition;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getKeyType() {
+        return keyType;
+    }
+
+    public void setKeyType(String keyType) {
+        this.keyType = keyType;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getValueType() {
+        return valueType;
+    }
+
+    public void setValueType(String valueType) {
+        this.valueType = valueType;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/src/test/java/at/esque/kafka/ControllerTest.java
+++ b/src/test/java/at/esque/kafka/ControllerTest.java
@@ -1,0 +1,50 @@
+package at.esque.kafka;
+
+import at.esque.kafka.topics.model.KafkaMessageBookWrapper;
+import at.esque.kafka.topics.model.KafkaMessageForMessageBook;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ControllerTest {
+
+    @Test
+    public void testAddMessagesToSend() {
+        // Given
+        List<KafkaMessageBookWrapper> messagesToSend = new ArrayList<>();
+        File playFile = new File("src/test/resources/csv_testfiles/testAddMessagesToSend.csv");
+
+        KafkaMessageForMessageBook message1Expected = new KafkaMessageForMessageBook();
+        message1Expected.setKey("${value1:UUID}");
+        message1Expected.setPartition(-1);
+        message1Expected.setTimestamp("2022-11-06T17:11:52.919Z");
+        message1Expected.setValue("{\"version\":0,\"newId\":\"${value1:UUID}\"}");
+
+        KafkaMessageForMessageBook message2Expected = new KafkaMessageForMessageBook();
+        message2Expected.setKey("${value2:UUID}");
+        message2Expected.setPartition(-1);
+        message2Expected.setTimestamp("2022-11-06T17:13:52.919Z");
+        message2Expected.setValue("{\"version\":0,\"newId\":\"${value2:UUID}\"}");
+
+        // When
+        Controller controller = new Controller();
+        controller.addMessagesToSend(messagesToSend, playFile);
+
+        // Then
+        assertEquals(2, messagesToSend.size());
+
+        assertEquals(message1Expected.getPartition(), messagesToSend.get(0).getWrappedMessage().getPartition());
+        assertEquals(message1Expected.getKey(), messagesToSend.get(0).getWrappedMessage().getKey());
+        assertEquals(message1Expected.getTimestamp(), messagesToSend.get(0).getWrappedMessage().getTimestamp());
+        assertEquals(message1Expected.getValue(), messagesToSend.get(0).getWrappedMessage().getValue());
+
+        assertEquals(message2Expected.getPartition(), messagesToSend.get(1).getWrappedMessage().getPartition());
+        assertEquals(message2Expected.getKey(), messagesToSend.get(1).getWrappedMessage().getKey());
+        assertEquals(message2Expected.getTimestamp(), messagesToSend.get(1).getWrappedMessage().getTimestamp());
+        assertEquals(message2Expected.getValue(), messagesToSend.get(1).getWrappedMessage().getValue());
+    }
+}

--- a/src/test/resources/csv_testfiles/testAddMessagesToSend.csv
+++ b/src/test/resources/csv_testfiles/testAddMessagesToSend.csv
@@ -1,0 +1,3 @@
+"key","partition","timestamp","value"
+"${value1:UUID}","-1","2022-11-06T17:11:52.919Z","{""version"":0,""newId"":""${value1:UUID}""}"
+"${value2:UUID}","-1","2022-11-06T17:13:52.919Z","{""version"":0,""newId"":""${value2:UUID}""}"


### PR DESCRIPTION
It looks like the Message Books feature had a bug which produces an error message like:
"Caused by: org.apache.commons.beanutils.ConversionException: Can't convert value 'id' to type class javafx.beans.property.StringProperty"

So we provide a fix where a dedicated class with String attributes is used (instead of StringProperties from the KafkaMessage class) for this feature.

Also includes the following minor changes:
- Fix typo in class KafkaMessageBookWrapper
- Add unit test for method addMessagesToSend (it was necessary to change the access modifier for this method to package-private for the unit test to work)
- Move the two classes to model package: KafkaMessageForMessageBook and KafkaMessageBookWrapper
