### PR TITLE
feat: add new datatype random int to be used in message playbooks

### DIFF
--- a/src/main/java/at/esque/kafka/Controller.java
+++ b/src/main/java/at/esque/kafka/Controller.java
@@ -142,7 +142,7 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
+import java.util.Random;
 
 public class Controller {
 
@@ -1586,28 +1586,51 @@ public class Controller {
         addReplacementEntries(replacementMap, message.getValue());
     }
 
-    private void addReplacementEntries(Map<String, String> replacementMap, String matchingString) {
-        String replaceMentKeyFormat = "${%s:%s}";
+    void addReplacementEntries(Map<String, String> replacementMap, String matchingString) {
+        String replacementKeyFormat = "${%s:%s}";
         Matcher matcher = REPLACER_PATTERN.matcher(matchingString);
+        Random rand = new Random();
 
         while (matcher.find()) {
             String identifier = matcher.group("identifier");
             String type = matcher.group("type");
-
             Serializable replacement;
-            switch (type) {
-                case "UUID":
-                    replacement = UUID.randomUUID();
-                    break;
-                default:
-                    throw new RuntimeException("Unsupported replacement type: " + type);
+
+            // Can safely generate random ints up to length 19 (within long range)
+            if (type.startsWith("RANDOM_INT_OF_LENGTH")) {
+                int lastUnderscoreIndex = type.lastIndexOf('_');
+                String numberPart = (lastUnderscoreIndex == -1) ? "" : type.substring(lastUnderscoreIndex + 1);
+
+                if (!numberPart.matches("\\d+")) {
+                    throw new RuntimeException("Invalid or missing length for random int type: " + type);
+                }
+
+                int lengthOfRandomInt;
+                try {
+                    lengthOfRandomInt = Integer.parseInt(numberPart);
+                    if (lengthOfRandomInt < 1 || lengthOfRandomInt > 19) {
+                        throw new RuntimeException("Random int length must be between 1 and 19: " + lengthOfRandomInt);
+                    }
+                } catch (NumberFormatException e) {
+                    throw new RuntimeException("Invalid or missing length for random int type: " + type, e);
+                }
+
+
+                long min = (long) Math.pow(10, lengthOfRandomInt - 1);
+                long max = (long) Math.pow(10, lengthOfRandomInt) - 1;
+
+                long randomNum = rand.nextLong(max - min + 1) + min;
+                replacement = String.valueOf(randomNum);
+
+            } else if ("UUID".equals(type)) {
+                replacement = UUID.randomUUID();
+
+            } else {
+                throw new RuntimeException("Unsupported replacement type: " + type);
             }
 
-            replacementMap.put(String.format(replaceMentKeyFormat, identifier, type), replacement.toString());
-
-
+            replacementMap.put(String.format(replacementKeyFormat, identifier, type), replacement.toString());
         }
-
     }
 
     private void centerStageOnControlledStage(Stage stage) {

--- a/src/test/java/at/esque/kafka/ControllerTest.java
+++ b/src/test/java/at/esque/kafka/ControllerTest.java
@@ -7,8 +7,7 @@ import static org.junit.Assert.*;
 
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 public class ControllerTest {
 
@@ -19,23 +18,36 @@ public class ControllerTest {
         File playFile = new File("src/test/resources/csv_testfiles/testAddMessagesToSend.csv");
 
         KafkaMessageForMessageBook message1Expected = new KafkaMessageForMessageBook();
-        message1Expected.setKey("${value1:UUID}");
+        message1Expected.setKey("${my_uuid1:UUID}");
         message1Expected.setPartition(-1);
         message1Expected.setTimestamp("2022-11-06T17:11:52.919Z");
-        message1Expected.setValue("{\"version\":0,\"newId\":\"${value1:UUID}\"}");
+        message1Expected.setValue("{\"version\":0,\"newId\":\"${my_uuid1:UUID}\"}");
 
         KafkaMessageForMessageBook message2Expected = new KafkaMessageForMessageBook();
-        message2Expected.setKey("${value2:UUID}");
+        message2Expected.setKey("${my_uuid2:UUID}");
         message2Expected.setPartition(-1);
         message2Expected.setTimestamp("2022-11-06T17:13:52.919Z");
-        message2Expected.setValue("{\"version\":0,\"newId\":\"${value2:UUID}\"}");
+        message2Expected.setValue("{\"version\":0,\"newId\":\"${my_uuid2:UUID}\"}");
+
+        KafkaMessageForMessageBook message3Expected = new KafkaMessageForMessageBook();
+        message3Expected.setKey("${my_int1:RANDOM_INT_OF_LENGTH_4}");
+        message3Expected.setPartition(-1);
+        message3Expected.setTimestamp("2022-11-06T17:14:52.919Z");
+        message3Expected.setValue("{\"version\":0,\"newId\":\"${my_int1:RANDOM_INT_OF_LENGTH_4}\"}");
+
+        KafkaMessageForMessageBook message4Expected = new KafkaMessageForMessageBook();
+        message4Expected.setKey("${my_int2:RANDOM_INT_OF_LENGTH_12}");
+        message4Expected.setPartition(-1);
+        message4Expected.setTimestamp("2022-11-06T17:17:52.919Z");
+        message4Expected.setValue("{\"version\":0,\"newId\":\"${my_int2:RANDOM_INT_OF_LENGTH_12}\"}");
+
 
         // When
         Controller controller = new Controller();
         controller.addMessagesToSend(messagesToSend, playFile);
 
         // Then
-        assertEquals(2, messagesToSend.size());
+        assertEquals(4, messagesToSend.size());
 
         assertEquals(message1Expected.getPartition(), messagesToSend.get(0).getWrappedMessage().getPartition());
         assertEquals(message1Expected.getKey(), messagesToSend.get(0).getWrappedMessage().getKey());
@@ -46,5 +58,160 @@ public class ControllerTest {
         assertEquals(message2Expected.getKey(), messagesToSend.get(1).getWrappedMessage().getKey());
         assertEquals(message2Expected.getTimestamp(), messagesToSend.get(1).getWrappedMessage().getTimestamp());
         assertEquals(message2Expected.getValue(), messagesToSend.get(1).getWrappedMessage().getValue());
+
+        assertEquals(message3Expected.getPartition(), messagesToSend.get(2).getWrappedMessage().getPartition());
+        assertEquals(message3Expected.getKey(), messagesToSend.get(2).getWrappedMessage().getKey());
+        assertEquals(message3Expected.getTimestamp(), messagesToSend.get(2).getWrappedMessage().getTimestamp());
+        assertEquals(message3Expected.getValue(), messagesToSend.get(2).getWrappedMessage().getValue());
+
+        assertEquals(message4Expected.getPartition(), messagesToSend.get(3).getWrappedMessage().getPartition());
+        assertEquals(message4Expected.getKey(), messagesToSend.get(3).getWrappedMessage().getKey());
+        assertEquals(message4Expected.getTimestamp(), messagesToSend.get(3).getWrappedMessage().getTimestamp());
+        assertEquals(message4Expected.getValue(), messagesToSend.get(3).getWrappedMessage().getValue());
     }
+
+    @Test
+    public void testAddReplacementEntries_UUID() {
+        // Given
+        Map<String, String> replacementMap = new HashMap<>();
+        String matchingString = "${value1:UUID}";
+        Controller controller = new Controller();
+
+        // When
+        controller.addReplacementEntries(replacementMap, matchingString);
+
+        // Then
+        assertEquals(1, replacementMap.size());
+        assertTrue(replacementMap.containsKey("${value1:UUID}"));
+        // Verify it's a valid UUID format
+        String uuidValue = replacementMap.get("${value1:UUID}");
+        assertNotNull(uuidValue);
+        UUID.fromString(uuidValue); // Should not throw exception
+    }
+
+    @Test
+    public void testAddReplacementEntries_MultipleUUIDs() {
+        // Given
+        Map<String, String> replacementMap = new HashMap<>();
+        String matchingString = "${value1:UUID} and ${value2:UUID}";
+        Controller controller = new Controller();
+
+        // When
+        controller.addReplacementEntries(replacementMap, matchingString);
+
+        // Then
+        assertEquals(2, replacementMap.size());
+        assertTrue(replacementMap.containsKey("${value1:UUID}"));
+        assertTrue(replacementMap.containsKey("${value2:UUID}"));
+    }
+
+    @Test
+    public void testAddReplacementEntries_RandomIntOfLength() {
+        // Given
+        Map<String, String> replacementMap = new HashMap<>();
+        String matchingString = "${id:RANDOM_INT_OF_LENGTH_5}";
+        Controller controller = new Controller();
+
+        // When
+        controller.addReplacementEntries(replacementMap, matchingString);
+
+        // Then
+        assertEquals(1, replacementMap.size());
+        assertTrue(replacementMap.containsKey("${id:RANDOM_INT_OF_LENGTH_5}"));
+        String randomInt = replacementMap.get("${id:RANDOM_INT_OF_LENGTH_5}");
+        assertEquals(5, randomInt.length());
+        assertTrue(randomInt.matches("\\d{5}"));
+    }
+
+    @Test
+    public void testAddReplacementEntries_RandomIntDifferentLengths() {
+        // Given
+        Map<String, String> replacementMap = new HashMap<>();
+        String matchingString = "${small:RANDOM_INT_OF_LENGTH_1} ${large:RANDOM_INT_OF_LENGTH_19}";
+        Controller controller = new Controller();
+
+        // When
+        controller.addReplacementEntries(replacementMap, matchingString);
+
+        // Then
+        assertEquals(2, replacementMap.size());
+        assertEquals(1, replacementMap.get("${small:RANDOM_INT_OF_LENGTH_1}").length());
+        assertEquals(19, replacementMap.get("${large:RANDOM_INT_OF_LENGTH_19}").length());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testAddReplacementEntries_InvalidLength_TooLarge() {
+        // Given
+        Map<String, String> replacementMap = new HashMap<>();
+        String matchingString = "${id:RANDOM_INT_OF_LENGTH_20}";
+        Controller controller = new Controller();
+
+        // When
+        controller.addReplacementEntries(replacementMap, matchingString);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testAddReplacementEntries_InvalidLength_Zero() {
+        // Given
+        Map<String, String> replacementMap = new HashMap<>();
+        String matchingString = "${id:RANDOM_INT_OF_LENGTH_0}";
+        Controller controller = new Controller();
+
+        // When
+        controller.addReplacementEntries(replacementMap, matchingString);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testAddReplacementEntries_InvalidLength_MissingNumber() {
+        // Given
+        Map<String, String> replacementMap = new HashMap<>();
+        String matchingString = "${id:RANDOM_INT_OF_LENGTH}";
+        Controller controller = new Controller();
+
+        // When
+        controller.addReplacementEntries(replacementMap, matchingString);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testAddReplacementEntries_UnsupportedType() {
+        // Given
+        Map<String, String> replacementMap = new HashMap<>();
+        String matchingString = "${id:UNSUPPORTED_TYPE}";
+        Controller controller = new Controller();
+
+        // When
+        controller.addReplacementEntries(replacementMap, matchingString);
+    }
+
+    @Test
+    public void testAddReplacementEntries_NoMatches() {
+        // Given
+        Map<String, String> replacementMap = new HashMap<>();
+        String matchingString = "This has no placeholders";
+        Controller controller = new Controller();
+
+        // When
+        controller.addReplacementEntries(replacementMap, matchingString);
+
+        // Then
+        assertEquals(0, replacementMap.size());
+    }
+
+    @Test
+    public void testAddReplacementEntries_MixedTypes() {
+        // Given
+        Map<String, String> replacementMap = new HashMap<>();
+        String matchingString = "{\"id\":\"${id:UUID}\",\"number\":${num:RANDOM_INT_OF_LENGTH_10}}";
+        Controller controller = new Controller();
+
+        // When
+        controller.addReplacementEntries(replacementMap, matchingString);
+
+        // Then
+        assertEquals(2, replacementMap.size());
+        assertTrue(replacementMap.containsKey("${id:UUID}"));
+        assertTrue(replacementMap.containsKey("${num:RANDOM_INT_OF_LENGTH_10}"));
+        assertEquals(10, replacementMap.get("${num:RANDOM_INT_OF_LENGTH_10}").length());
+    }
+
 }

--- a/src/test/resources/csv_testfiles/testAddMessagesToSend.csv
+++ b/src/test/resources/csv_testfiles/testAddMessagesToSend.csv
@@ -1,3 +1,5 @@
 "key","partition","timestamp","value"
-"${value1:UUID}","-1","2022-11-06T17:11:52.919Z","{""version"":0,""newId"":""${value1:UUID}""}"
-"${value2:UUID}","-1","2022-11-06T17:13:52.919Z","{""version"":0,""newId"":""${value2:UUID}""}"
+"${my_uuid1:UUID}","-1","2022-11-06T17:11:52.919Z","{""version"":0,""newId"":""${my_uuid1:UUID}""}"
+"${my_uuid2:UUID}","-1","2022-11-06T17:13:52.919Z","{""version"":0,""newId"":""${my_uuid2:UUID}""}"
+"${my_int1:RANDOM_INT_OF_LENGTH_4}","-1","2022-11-06T17:14:52.919Z","{""version"":0,""newId"":""${my_int1:RANDOM_INT_OF_LENGTH_4}""}"
+"${my_int2:RANDOM_INT_OF_LENGTH_12}","-1","2022-11-06T17:17:52.919Z","{""version"":0,""newId"":""${my_int2:RANDOM_INT_OF_LENGTH_12}""}"


### PR DESCRIPTION
I implemented a new datatype "RANDOM_INT_OF_LENGTH_XX" to be used in message playbooks.
It generates random numbers/integers up to length 19 with the same syntax as the already existing UUIDs.

So for example:

`${my_int1:RANDOM_INT_OF_LENGTH_4}` 
would be replaced with 3269 for example in all occurrences.

Another example would be:

`${my_int2:RANDOM_INT_OF_LENGTH_12}` 
would be replaced with 385732170419 for example.

I replaced the existing switch statement with an if/else statement so that "startsWith" can be used for dynamic evaluation of the datatype in regards to the desired length.